### PR TITLE
ttc-connectors-dummytwitter to 1.0.42

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -15,7 +15,7 @@ dependencies:
   version: 0.1.8
 - name: ttc-connectors-dummytwitter
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.51
+  version: 1.0.42
 - name: ttc-dashboard-ui
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.37


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 1.0.42