### PR TITLE
ttc-connectors-dummytwitter to 1.0.45

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.58
 - name: ttc-connectors-dummytwitter
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.44
+  version: 1.0.45
 - name: ttc-dashboard-ui
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.38


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 1.0.45