### PR TITLE
ttc-connectors-dummytwitter to 1.0.46

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 0.2.0
 - name: ttc-connectors-dummytwitter
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.50
+  version: 1.0.46
 - name: ttc-dashboard-ui
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.38


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 1.0.46