### PR TITLE
ttc-connectors-processing to 1.0.24

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
   version: 1.0.48
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.23
+  version: 1.0.24
 - name: ttc-dashboard-ui
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.38


### PR DESCRIPTION
Promote ttc-connectors-processing to version 1.0.24