### PR TITLE
ttc-connectors-ranking to 1.0.21

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -19,6 +19,9 @@ dependencies:
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.24
+- name: ttc-connectors-ranking
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.21
 - name: ttc-dashboard-ui
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.38


### PR DESCRIPTION
Promote ttc-connectors-ranking to version 1.0.21