### PR TITLE
ttc-connectors-processing to 1.0.25

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
   version: 1.0.50
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.24
+  version: 1.0.25
 - name: ttc-connectors-ranking
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.25


### PR DESCRIPTION
Promote ttc-connectors-processing to version 1.0.25