### PR TITLE
ttc-connectors-processing to 1.0.26

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
   version: 1.0.51
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.25
+  version: 1.0.26
 - name: ttc-connectors-ranking
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.27


### PR DESCRIPTION
Promote ttc-connectors-processing to version 1.0.26