### PR TITLE
ttc-connectors-ranking to 1.0.31

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -21,7 +21,7 @@ dependencies:
   version: 1.0.28
 - name: ttc-connectors-ranking
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.29
+  version: 1.0.31
 - name: ttc-connectors-reward
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.20


### PR DESCRIPTION
Promote ttc-connectors-ranking to version 1.0.31