### PR TITLE
ttc-connectors-processing to 1.0.19

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -18,7 +18,7 @@ dependencies:
   version: 1.0.56
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.28
+  version: 1.0.19
 - name: ttc-connectors-ranking
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.32


### PR DESCRIPTION
Promote ttc-connectors-processing to version 1.0.19