### PR TITLE
ttc-connectors-dummytwitter to 1.0.42

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -13,6 +13,9 @@ dependencies:
 - name: rabbitmq
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.8.0
+- name: ttc-connectors-dummytwitter
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.42
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.20


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 1.0.42